### PR TITLE
fix: 페이지에 맞춰 주문 생성 API 분리

### DIFF
--- a/src/main/java/shoong/web_backend/domain/orders/controller/OrdersController.java
+++ b/src/main/java/shoong/web_backend/domain/orders/controller/OrdersController.java
@@ -5,9 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import shoong.web_backend.domain.orders.dto.OrderCreateRequestDto;
+import shoong.web_backend.domain.orders.dto.OrdersCreateRequestDto;
 import shoong.web_backend.domain.orders.dto.OrdersDetailDto;
 import shoong.web_backend.domain.orders.dto.OrdersResponseDto;
+import shoong.web_backend.domain.orders.dto.OrdersSuccessRequestDto;
 import shoong.web_backend.domain.orders.service.OrdersService;
 import shoong.web_backend.domain.user.dto.form.CustomUserDetails;
 
@@ -21,16 +22,28 @@ public class OrdersController {
     private final OrdersService ordersService;
 
     // 주문 생성 API
-    @PostMapping("/success")
-    public ResponseEntity<OrdersResponseDto> createOrder(
+    @PostMapping("/create")
+    public ResponseEntity<OrdersResponseDto> createOrderDraft(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody OrderCreateRequestDto request) {
+            @RequestBody OrdersCreateRequestDto request) {
 
-        OrdersResponseDto savedOrder = ordersService.saveOrderWithSelectedCartItems(
+        OrdersResponseDto orderDraft = ordersService.createOrderDraft(
                 userDetails.getUserId(),
                 request.getSelectedCartIds()
         );
-        return ResponseEntity.ok(savedOrder);
+        return ResponseEntity.ok(orderDraft);
+    }
+
+    @PostMapping("/success")
+    public ResponseEntity<OrdersResponseDto> finalizeOrder(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody OrdersSuccessRequestDto request) {
+
+        OrdersResponseDto finalizedOrder = ordersService.finalizeOrder(
+                userDetails.getUserId(),
+                request.getOrderId()
+        );
+        return ResponseEntity.ok(finalizedOrder);
     }
 
     @GetMapping("/list")

--- a/src/main/java/shoong/web_backend/domain/orders/controller/OrdersController.java
+++ b/src/main/java/shoong/web_backend/domain/orders/controller/OrdersController.java
@@ -41,7 +41,8 @@ public class OrdersController {
 
         OrdersResponseDto finalizedOrder = ordersService.finalizeOrder(
                 userDetails.getUserId(),
-                request.getOrderId()
+                request.getOrderId(),
+                request.getOrderAddress()
         );
         return ResponseEntity.ok(finalizedOrder);
     }

--- a/src/main/java/shoong/web_backend/domain/orders/dto/OrdersCreateRequestDto.java
+++ b/src/main/java/shoong/web_backend/domain/orders/dto/OrdersCreateRequestDto.java
@@ -9,10 +9,10 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
-public class OrderCreateRequestDto {
+public class OrdersCreateRequestDto {
     private List<Long> selectedCartIds;
 
-    public OrderCreateRequestDto(List<Long> selectedCartIds) {
+    public OrdersCreateRequestDto(List<Long> selectedCartIds) {
         this.selectedCartIds = selectedCartIds;
     }
 }

--- a/src/main/java/shoong/web_backend/domain/orders/dto/OrdersSuccessRequestDto.java
+++ b/src/main/java/shoong/web_backend/domain/orders/dto/OrdersSuccessRequestDto.java
@@ -1,0 +1,13 @@
+package shoong.web_backend.domain.orders.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OrdersSuccessRequestDto {
+    private Long orderId;
+    private String orderAddress;
+}

--- a/src/main/java/shoong/web_backend/domain/orders/entity/Orders.java
+++ b/src/main/java/shoong/web_backend/domain/orders/entity/Orders.java
@@ -1,10 +1,7 @@
 package shoong.web_backend.domain.orders.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import shoong.web_backend.domain.order_item.entity.OrderItem;
 import shoong.web_backend.domain.user.entity.User;
 
@@ -15,6 +12,7 @@ import java.util.List;
 @Entity
 @Builder
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "orders")
@@ -44,6 +42,7 @@ public class Orders {
     public static Orders of(User user) {
         return Orders.builder()
                 .user(user)
+                .orderAddress(user.getUserAddress())
                 .totalPrice(0L)
                 .orderDate(LocalDateTime.now())
                 .build();

--- a/src/main/java/shoong/web_backend/domain/orders/service/OrdersService.java
+++ b/src/main/java/shoong/web_backend/domain/orders/service/OrdersService.java
@@ -46,7 +46,7 @@ public class OrdersService {
      * @param selectedCartIds 주문할 장바구니 아이템 ID 목록
      */
     @Transactional
-    public OrdersResponseDto saveOrderWithSelectedCartItems(Long userId, List<Long> selectedCartIds) {
+    public OrdersResponseDto createOrderDraft(Long userId, List<Long> selectedCartIds) {
         User user = findUserById(userId);
         List<Cart> selectedCarts = findSelectedCarts(userId, selectedCartIds);
         validateCartsNotEmpty(selectedCarts);
@@ -62,7 +62,7 @@ public class OrdersService {
             acquireItemLocks(sortedItemIds, lockMap);
 
             // 재고 검증
-            validateStockAvailability(selectedCarts);
+            validateStockAvailabilityWithCart(selectedCarts);
 
             // 주문 생성 및 처리
             Orders order = createOrderFromSelectedCarts(user, selectedCarts);
@@ -70,12 +70,6 @@ public class OrdersService {
 
             List<OrderItem> orderItems = savedOrder.getOrderItems();
             orderItemRepository.saveAll(orderItems);
-
-            // 재고 감소
-            decreaseItemStock(orderItems);
-
-            // 선택된 카트 아이템만 제거
-            removeSelectedCartItems(selectedCartIds);
 
             return convertToOrderResponseDto(savedOrder);
 
@@ -87,6 +81,48 @@ public class OrdersService {
             releaseAllLocks(lockMap);
         }
     }
+
+    @Transactional
+    public OrdersResponseDto finalizeOrder(Long userId, Long orderId) {
+        Orders order = findOrderById(orderId);
+//        validateUserOwnership(order, userId);
+
+        List<OrderItem> orderItems = order.getOrderItems();
+
+        List<Long> itemIds = orderItems.stream()
+                .map(oi -> oi.getItem().getItemId())
+                .distinct()
+                .sorted()
+                .toList();
+
+        Map<Long, RLock> lockMap = new HashMap<>();
+        try {
+            acquireItemLocks(itemIds, lockMap);
+            validateStockAvailabilityWithOrder(orderItems); // ✅ 재확인 안전망
+
+            decreaseItemStock(orderItems); // ✅ 실제 차감
+            removeSelectedCartItems(userId, order);
+
+            return convertToOrderResponseDto(order);
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("주문 확정 중 인터럽트 발생", e);
+        } finally {
+            releaseAllLocks(lockMap);
+        }
+    }
+
+    private Orders findOrderById(Long orderId) {
+        return ordersRepository.findById(orderId)
+                .orElseThrow(() -> new NotFoundException("해당 orderId의 주문 조회를 실패했습니다."));
+    }
+
+//    private void validateUserOwnership(Orders order, Long userId) {
+//        if (!order.getUser().getId().equals(userId)) {
+//            throw new UnauthorizedAccessException("해당 주문에 접근할 권한이 없습니다.");
+//        }
+//    }
 
     // ===== 락 관련 헬퍼 메서드 =====
     private void acquireItemLocks(List<Long> sortedItemIds, Map<Long, RLock> lockMap)
@@ -115,10 +151,25 @@ public class OrdersService {
     }
 
     // ===== 재고 검증 헬퍼 메서드 =====
-    private void validateStockAvailability(List<Cart> selectedCarts) {
+    private void validateStockAvailabilityWithCart(List<Cart> selectedCarts) {
         for (Cart cart : selectedCarts) {
             Item item = cart.getItem();
             int requestedQuantity = cart.getCartQuantity();
+            int availableStock = item.getItemQuantity();
+
+            if (requestedQuantity > availableStock) {
+                throw new IllegalStateException(
+                        String.format("상품 '%s'의 재고가 부족합니다. (요청: %d개, 재고: %d개)",
+                                item.getItemName(), requestedQuantity, availableStock)
+                );
+            }
+        }
+    }
+
+    private void validateStockAvailabilityWithOrder(List<OrderItem> orderItems) {
+        for (OrderItem orderItem : orderItems) {
+            Item item = orderItem.getItem();
+            int requestedQuantity = orderItem.getOrderItemQuantity();
             int availableStock = item.getItemQuantity();
 
             if (requestedQuantity > availableStock) {
@@ -154,8 +205,21 @@ public class OrdersService {
                 .collect(Collectors.toSet());
     }
 
-    private void removeSelectedCartItems(List<Long> selectedCartIds) {
-        cartRepository.deleteByCartIdIn(selectedCartIds);
+    private void removeSelectedCartItems(Long userId, Orders order) {
+        // 주문에서 사용된 itemId들 추출
+        Set<Long> orderedItemIds = order.getOrderItems().stream()
+                .map(oi -> oi.getItem().getItemId())
+                .collect(Collectors.toSet());
+
+        // 내 카트 목록 조회
+        List<Cart> myCarts = cartRepository.findByUserId(userId);
+
+        // 주문된 itemId와 일치하는 카트만 필터링
+        List<Cart> cartsToRemove = myCarts.stream()
+                .filter(cart -> orderedItemIds.contains(cart.getItem().getItemId()))
+                .toList();
+
+        cartRepository.deleteAll(cartsToRemove);
     }
 
     // ===== 사용자 관련 헬퍼 메서드 =====
@@ -235,56 +299,3 @@ public class OrdersService {
                 .toList();
     }
 }
-
-
-
-//@Service
-//@RequiredArgsConstructor
-//@Builder
-//public class OrdersService {
-//
-//    private final OrdersRepository ordersRepository;
-//    private final CartRepository cartRepository;
-//    private final UserRepository userRepository;
-//
-//    @Transactional
-//    public OrdersResponseDto saveOrderWithCartItems(Long userId) {
-//        // 1. 유저 장바구니 조회
-//        List<Cart> carts = cartRepository.findAllByUserId(userId);
-//        User getUser = userRepository.findById(userId)
-//                .orElseThrow(() -> new NotFoundException("해당 userID의 유저 조회를 실패하였습니다."));
-//
-//        if (carts.isEmpty()) {
-//            throw new IllegalStateException("장바구니가 비어있습니다.");
-//        }
-//
-//        Orders order = Orders.of(getUser);
-//
-//        // 3. 장바구니 -> OrderItem 변환해서 Orders에 추가
-//        for (Cart cart : carts) {
-//            OrderItem orderItem = OrderItem.of(
-//                    order,
-//                    cart.getItem(),
-//                    cart.getCartQuantity(),
-//                    (long) (cart.getItem().getPrice() * cart.getCartQuantity() * cart.getItem().getDiscountRate())
-//                    // 상품 가격 기준
-//            );
-//            order.addOrderItem(orderItem);
-//        }
-//
-//        // 4. Orders 저장 (OrderItem은 cascade로 같이 저장됨)
-//        Orders savedOrder = ordersRepository.save(order);
-//
-//        // 5. 장바구니 비우기
-//        cartRepository.deleteAllByUserId(userId);
-//
-//        return OrdersResponseDto.builder()
-//                .orderId(savedOrder.getOrderId())
-//                .totalPrice(savedOrder.getTotalPrice())
-//                .orderDate(savedOrder.getOrderDate())
-//                .orderItems(savedOrder.getOrderItems().stream()
-//                        .map(OrderItemDto::from)
-//                        .toList())
-//                .build();
-//    }
-//}

--- a/src/main/java/shoong/web_backend/domain/orders/service/OrdersService.java
+++ b/src/main/java/shoong/web_backend/domain/orders/service/OrdersService.java
@@ -83,7 +83,7 @@ public class OrdersService {
     }
 
     @Transactional
-    public OrdersResponseDto finalizeOrder(Long userId, Long orderId) {
+    public OrdersResponseDto finalizeOrder(Long userId, Long orderId, String orderAddress) {
         Orders order = findOrderById(orderId);
 //        validateUserOwnership(order, userId);
 
@@ -102,9 +102,9 @@ public class OrdersService {
 
             decreaseItemStock(orderItems); // ✅ 실제 차감
             removeSelectedCartItems(userId, order);
+            order.setOrderAddress(orderAddress);
 
             return convertToOrderResponseDto(order);
-
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("주문 확정 중 인터럽트 발생", e);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#1 


## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

주문 생성과 동시에 장바구니가 비워지는 로직을 두 개의 API로 분리하였다.


### 스크린샷 (선택)



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


